### PR TITLE
FIX Issues 878 and 834 - usec overflow (using system clock)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,68 @@ on:
     branches:
       - "master"
       
-jobs:        
+jobs:
+  buildlinux:
+    name: Linux x64
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Prepare Environment
+        run: |
+            sudo apt-get install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-randr0 libxkbcommon-x11-0
+
+      - name: Prepare Qt Libraries
+        uses: jurplel/install-qt-action@v3
+
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Compile
+        run: |
+          qmake CONFIG+=release PREFIX=/usr SavvyCAN.pro
+          make -j`grep -c ^processor /proc/cpuinfo`
+          
+      - name: Package     
+        run: |
+          make INSTALL_ROOT=appdir install
+          wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+          chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+          ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/SavvyCAN.desktop -appimage -extra-plugins=iconengines,platformthemes/libqgtk3.so,canbus
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SavvyCAN-Linux_x64.AppImage
+          path: SavvyCAN-*x86_64.AppImage
+      
+  buildmacos:
+    name: macOS x64
+    runs-on: macos-12
+
+    steps:
+      - name: Prepare macOS Environment
+        run: |
+            brew install qt5
+            brew link qt5 --force
+
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Compile     
+        run: |
+          qmake CONFIG+=release CONFIG+=sdk_no_version_check SavvyCAN.pro
+          make -j`sysctl kern.aioprocmax | awk '{print $2}'`
+
+      - name: Package     
+        run: |
+          mkdir -p SavvyCAN.app/Contents/MacOS/help
+          cp -R help/* SavvyCAN.app/Contents/MacOS/help
+          macdeployqt SavvyCAN.app -dmg
+      
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SavvyCAN-macOS_x64.dmg
+          path: SavvyCAN.dmg
+          
   buildwindows:
     name: Windows x64
     runs-on: windows-2019
@@ -62,7 +123,7 @@ jobs:
   pre-release:
     name: "pre-release"
     runs-on: "ubuntu-latest"
-    needs: [buildwindows]
+    needs: [buildwindows, buildmacos, buildlinux]
 
     steps:
       - uses: actions/checkout@v3
@@ -78,5 +139,6 @@ jobs:
           prerelease: true
           title: "Development Build"
           files: |
+            SavvyCAN-Linux_x64.AppImage/SavvyCAN-*x86_64.AppImage
             SavvyCAN-Windows_x64_CIBuild.zip
-
+            SavvyCAN-macOS_x64.dmg/SavvyCAN.dmg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - "master"
@@ -142,3 +140,30 @@ jobs:
             SavvyCAN-Linux_x64.AppImage/SavvyCAN-*x86_64.AppImage
             SavvyCAN-Windows_x64_CIBuild.zip
             SavvyCAN-macOS_x64.dmg/SavvyCAN.dmg
+          
+  notify:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+    needs: [buildwindows, buildmacos, buildlinux]
+    steps:
+      - id: msg_var
+        name: remove newlines
+        run: |
+          export release_msg=$(cat << EOF
+          ${{ github.event.head_commit.message }} 
+          EOF
+          )
+          release_msg="${release_msg//$'\n'/'-'}"
+          release_msg="${release_msg//$'\r'/'-'}"
+          release_msg="${release_msg//$'('/'-'}"
+          release_msg="${release_msg//$')'/'-'}"
+          echo $release_msg
+          echo "::set-output name=msg::$release_msg"
+                                                                  
+      - name: Notify Discord
+        run: |
+          curl -i -H "Accept: application/json" \
+          -H "Content-Type:application/json" \
+          -X POST \
+          --data "{\"content\": null,\"embeds\": [{\"title\": \"${{ github.repository }} Build Complete\",      \"description\": \"${{ steps.msg_var.outputs.msg }} \\nCommit: ${{ github.sha }}\\n[Build Artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)\",      \"color\": 5131997,      \"author\": {        \"name\": \"Github Builds\"      }    }  ]}" \
+          https://discord.com/api/webhooks/${{ secrets.WEBHOOK_ID }}/${{ secrets.WEBHOOK_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,72 +1,13 @@
 name: Build
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - "master"
       
-jobs:
-  buildlinux:
-    name: Linux x64
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Prepare Environment
-        run: |
-            sudo apt-get install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-randr0 libxkbcommon-x11-0
-
-      - name: Prepare Qt Libraries
-        uses: jurplel/install-qt-action@v3
-
-      - name: Clone
-        uses: actions/checkout@v3
-
-      - name: Compile
-        run: |
-          qmake CONFIG+=release PREFIX=/usr SavvyCAN.pro
-          make -j`grep -c ^processor /proc/cpuinfo`
-          
-      - name: Package     
-        run: |
-          make INSTALL_ROOT=appdir install
-          wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-          chmod a+x linuxdeployqt-continuous-x86_64.AppImage
-          ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/SavvyCAN.desktop -appimage -extra-plugins=iconengines,platformthemes/libqgtk3.so,canbus
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: SavvyCAN-Linux_x64.AppImage
-          path: SavvyCAN-*x86_64.AppImage
-      
-  buildmacos:
-    name: macOS x64
-    runs-on: macos-12
-
-    steps:
-      - name: Prepare macOS Environment
-        run: |
-            brew install qt5
-            brew link qt5 --force
-
-      - name: Clone
-        uses: actions/checkout@v3
-
-      - name: Compile     
-        run: |
-          qmake CONFIG+=release CONFIG+=sdk_no_version_check SavvyCAN.pro
-          make -j`sysctl kern.aioprocmax | awk '{print $2}'`
-
-      - name: Package     
-        run: |
-          mkdir -p SavvyCAN.app/Contents/MacOS/help
-          cp -R help/* SavvyCAN.app/Contents/MacOS/help
-          macdeployqt SavvyCAN.app -dmg
-      
-      - uses: actions/upload-artifact@v4
-        with:
-          name: SavvyCAN-macOS_x64.dmg
-          path: SavvyCAN.dmg
-          
+jobs:        
   buildwindows:
     name: Windows x64
     runs-on: windows-2019
@@ -121,7 +62,7 @@ jobs:
   pre-release:
     name: "pre-release"
     runs-on: "ubuntu-latest"
-    needs: [buildwindows, buildmacos, buildlinux]
+    needs: [buildwindows]
 
     steps:
       - uses: actions/checkout@v3
@@ -137,33 +78,5 @@ jobs:
           prerelease: true
           title: "Development Build"
           files: |
-            SavvyCAN-Linux_x64.AppImage/SavvyCAN-*x86_64.AppImage
             SavvyCAN-Windows_x64_CIBuild.zip
-            SavvyCAN-macOS_x64.dmg/SavvyCAN.dmg
-          
-  notify:
-    name: Notify Discord
-    runs-on: ubuntu-latest
-    needs: [buildwindows, buildmacos, buildlinux]
-    steps:
-      - id: msg_var
-        name: remove newlines
-        run: |
-          export release_msg=$(cat << EOF
-          ${{ github.event.head_commit.message }} 
-          EOF
-          )
-          release_msg="${release_msg//$'\n'/'-'}"
-          release_msg="${release_msg//$'\r'/'-'}"
-          release_msg="${release_msg//$'('/'-'}"
-          release_msg="${release_msg//$')'/'-'}"
-          echo $release_msg
-          echo "::set-output name=msg::$release_msg"
-                                                                  
-      - name: Notify Discord
-        run: |
-          curl -i -H "Accept: application/json" \
-          -H "Content-Type:application/json" \
-          -X POST \
-          --data "{\"content\": null,\"embeds\": [{\"title\": \"${{ github.repository }} Build Complete\",      \"description\": \"${{ steps.msg_var.outputs.msg }} \\nCommit: ${{ github.sha }}\\n[Build Artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)\",      \"color\": 5131997,      \"author\": {        \"name\": \"Github Builds\"      }    }  ]}" \
-          https://discord.com/api/webhooks/${{ secrets.WEBHOOK_ID }}/${{ secrets.WEBHOOK_TOKEN }}
+

--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -222,8 +222,7 @@ bool CANConManager::sendFrame(const CANFrame& pFrame)
             workingFrame.isReceived = false;
             if (useSystemTime)
             {
-                qint64 currentTimeMs = QDateTime::currentMSecsSinceEpoch();
-                workingFrame.setTimeStamp(QCanBusFrame::TimeStamp(currentTimeMs / 1000, (currentTimeMs % 1000) * 1000));
+                workingFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
             }
             else
             {

--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -222,7 +222,8 @@ bool CANConManager::sendFrame(const CANFrame& pFrame)
             workingFrame.isReceived = false;
             if (useSystemTime)
             {
-                workingFrame.setTimeStamp(QCanBusFrame::TimeStamp(0,QDateTime::currentMSecsSinceEpoch() * 1000));
+                qint64 currentTimeMs = QDateTime::currentMSecsSinceEpoch();
+                workingFrame.setTimeStamp(QCanBusFrame::TimeStamp(currentTimeMs / 1000, (currentTimeMs % 1000) * 1000));
             }
             else
             {

--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -222,7 +222,7 @@ bool CANConManager::sendFrame(const CANFrame& pFrame)
             workingFrame.isReceived = false;
             if (useSystemTime)
             {
-                workingFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
+                workingFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul));
             }
             else
             {

--- a/connections/canserver.cpp
+++ b/connections/canserver.cpp
@@ -214,7 +214,7 @@ void CANserver::readNetworkData()
             frame_p->setFrameType(QCanBusFrame::DataFrame);
             frame_p->isReceived = true;
         
-            frame_p->setTimeStamp(QCanBusFrame::TimeStamp(0, QDateTime::currentMSecsSinceEpoch() * 1000ul));
+            frame_p->setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul));
 
             frame_p->setPayload(datagram.mid(dataByteLocation, length));
         

--- a/connections/gvretserial.cpp
+++ b/connections/gvretserial.cpp
@@ -685,8 +685,7 @@ void GVRetSerial::procRXChar(unsigned char c)
             buildTimestamp += timeBasis;
             if (useSystemTime)
             {
-                buildTimestamp = QDateTime::currentMSecsSinceEpoch();
-                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(buildTimestamp / 1000, (buildTimestamp % 1000) * 1000));
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
             } else {
                 buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
             }
@@ -772,9 +771,10 @@ void GVRetSerial::procRXChar(unsigned char c)
             buildTimestamp += timeBasis;
             if (useSystemTime)
             {
-                buildTimestamp = QDateTime::currentMSecsSinceEpoch() * 1000l;
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
+            } else {
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
             }
-            buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
             break;
         case 4:
             buildId = c;

--- a/connections/gvretserial.cpp
+++ b/connections/gvretserial.cpp
@@ -685,9 +685,11 @@ void GVRetSerial::procRXChar(unsigned char c)
             buildTimestamp += timeBasis;
             if (useSystemTime)
             {
-                buildTimestamp = QDateTime::currentMSecsSinceEpoch() * 1000l;
+                buildTimestamp = QDateTime::currentMSecsSinceEpoch();
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(buildTimestamp / 1000, (buildTimestamp % 1000) * 1000));
+            } else {
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
             }
-            buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
             break;
         case 4:
             buildId = c;

--- a/connections/gvretserial.cpp
+++ b/connections/gvretserial.cpp
@@ -685,7 +685,7 @@ void GVRetSerial::procRXChar(unsigned char c)
             buildTimestamp += timeBasis;
             if (useSystemTime)
             {
-                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul));
             } else {
                 buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
             }
@@ -771,7 +771,7 @@ void GVRetSerial::procRXChar(unsigned char c)
             buildTimestamp += timeBasis;
             if (useSystemTime)
             {
-                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul));
             } else {
                 buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
             }

--- a/connections/lawicel_serial.cpp
+++ b/connections/lawicel_serial.cpp
@@ -493,7 +493,8 @@ void LAWICELSerial::readSerialData()
 
             if (useSystemTime)
             {
-                buildTimestamp = QDateTime::currentMSecsSinceEpoch() * 1000l;
+                buildTimestamp = QDateTime::currentMSecsSinceEpoch();
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(buildTimestamp / 1000, (buildTimestamp % 1000) * 1000));
             }
             else
             {
@@ -508,8 +509,8 @@ void LAWICELSerial::readSerialData()
                     //Default to system time if timestamps are disabled.
                     buildTimestamp = QDateTime::currentMSecsSinceEpoch() * 1000l;
                 }
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
             }
-            buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
 
             switch (mBuildLine[0].toLatin1())
             {

--- a/connections/lawicel_serial.cpp
+++ b/connections/lawicel_serial.cpp
@@ -493,7 +493,7 @@ void LAWICELSerial::readSerialData()
 
             if (useSystemTime)
             {
-                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul));
             }
             else
             {
@@ -502,13 +502,13 @@ void LAWICELSerial::readSerialData()
                 {
                     //Four bytes after the end of the data bytes.
                     buildTimestamp = mBuildLine.mid(5 + mBuildLine.mid(4, 1).toInt() * 2, 4).toInt(nullptr, 16) * 1000l;
+                    buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
                 }
                 else
                 {
                     //Default to system time if timestamps are disabled.
-                    buildTimestamp = QDateTime::currentMSecsSinceEpoch() * 1000l;
+                    buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul));
                 }
-                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, buildTimestamp));
             }
 
             switch (mBuildLine[0].toLatin1())

--- a/connections/lawicel_serial.cpp
+++ b/connections/lawicel_serial.cpp
@@ -493,8 +493,7 @@ void LAWICELSerial::readSerialData()
 
             if (useSystemTime)
             {
-                buildTimestamp = QDateTime::currentMSecsSinceEpoch();
-                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(buildTimestamp / 1000, (buildTimestamp % 1000) * 1000));
+                buildFrame.setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
             }
             else
             {

--- a/connections/mqtt_bus.cpp
+++ b/connections/mqtt_bus.cpp
@@ -302,7 +302,7 @@ void MQTT_BUS::clientMessageReceived(const QMQTT::Message& message)
         frame_p->isReceived = true;
         if (useSystemTime)
         {
-            frame_p->setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
+            frame_p->setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul));
         }
         else frame_p->setTimeStamp(QCanBusFrame::TimeStamp(0, timeStamp));
 

--- a/connections/mqtt_bus.cpp
+++ b/connections/mqtt_bus.cpp
@@ -302,8 +302,7 @@ void MQTT_BUS::clientMessageReceived(const QMQTT::Message& message)
         frame_p->isReceived = true;
         if (useSystemTime)
         {
-            qint64 currentTimeMs = QDateTime::currentMSecsSinceEpoch();
-            frame_p->setTimeStamp(QCanBusFrame::TimeStamp(currentTimeMs / 1000, (currentTimeMs % 1000) * 1000));
+            frame_p->setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
         }
         else frame_p->setTimeStamp(QCanBusFrame::TimeStamp(0, timeStamp));
 

--- a/connections/mqtt_bus.cpp
+++ b/connections/mqtt_bus.cpp
@@ -302,7 +302,8 @@ void MQTT_BUS::clientMessageReceived(const QMQTT::Message& message)
         frame_p->isReceived = true;
         if (useSystemTime)
         {
-            frame_p->setTimeStamp(QCanBusFrame::TimeStamp(0, QDateTime::currentMSecsSinceEpoch() * 1000ul));
+            qint64 currentTimeMs = QDateTime::currentMSecsSinceEpoch();
+            frame_p->setTimeStamp(QCanBusFrame::TimeStamp(currentTimeMs / 1000, (currentTimeMs % 1000) * 1000));
         }
         else frame_p->setTimeStamp(QCanBusFrame::TimeStamp(0, timeStamp));
 

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -211,7 +211,8 @@ void SerialBusConnection::framesReceived()
                 frame_p->isReceived = !recFrame.hasLocalEcho();
 
                 if (useSystemTime) {
-                    frame_p->setTimeStamp(QCanBusFrame::TimeStamp(0, QDateTime::currentMSecsSinceEpoch() * 1000ul));
+                    qint64 currentTimeMs = QDateTime::currentMSecsSinceEpoch();
+                    frame_p->setTimeStamp(QCanBusFrame::TimeStamp(currentTimeMs / 1000, (currentTimeMs % 1000) * 1000));
                 }
                 else frame_p->setTimeStamp(QCanBusFrame::TimeStamp(0, (recFrame.timeStamp().seconds() * 1000000ul + recFrame.timeStamp().microSeconds()) - timeBasis));
 

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -211,7 +211,7 @@ void SerialBusConnection::framesReceived()
                 frame_p->isReceived = !recFrame.hasLocalEcho();
 
                 if (useSystemTime) {
-                    frame_p->setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
+                    frame_p->setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul));
                 }
                 else frame_p->setTimeStamp(QCanBusFrame::TimeStamp(0, (recFrame.timeStamp().seconds() * 1000000ul + recFrame.timeStamp().microSeconds()) - timeBasis));
 

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -211,8 +211,7 @@ void SerialBusConnection::framesReceived()
                 frame_p->isReceived = !recFrame.hasLocalEcho();
 
                 if (useSystemTime) {
-                    qint64 currentTimeMs = QDateTime::currentMSecsSinceEpoch();
-                    frame_p->setTimeStamp(QCanBusFrame::TimeStamp(currentTimeMs / 1000, (currentTimeMs % 1000) * 1000));
+                    frame_p->setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch()));
                 }
                 else frame_p->setTimeStamp(QCanBusFrame::TimeStamp(0, (recFrame.timeStamp().seconds() * 1000000ul + recFrame.timeStamp().microSeconds()) - timeBasis));
 


### PR DESCRIPTION
Using `TimeStamp::TimeStamp(qint64 s = 0, qint64 usec = 0)` has a caveat

> Note: The TimeStamp is not normalized, i.e. microseconds greater 1000000 are not converted to seconds.

So let's use proper method:

`...setTimeStamp(QCanBusFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul))`

This is making the time progressing as expected; it's not clear why it still starts from `0 UTC`

Reported ISSUES: https://github.com/collin80/SavvyCAN/issues/834 https://github.com/collin80/SavvyCAN/issues/878
